### PR TITLE
Add .deployignore file to exclude unnecessary files during deployment

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -1,0 +1,2 @@
+.git
+app/node_modules


### PR DESCRIPTION
The .deployignore file is added to exclude the .git directory and node_modules folder from being deployed, ensuring a cleaner and more efficient deployment process.