### PR TITLE
Fix missing quote in docker compose command

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -80,5 +80,5 @@ jobs:
         run: rsync -avz --delete --exclude-from=.deployignore . ${{ secrets.PROD_DEPLOY_SSH_USER }}@${{ secrets.PROD_DEPLOY_SSH_HOST }}:${{ secrets.PROD_DEPLOY_TARGET_DIR }}
       - name: Docker Management
         run: |
-          ssh ${{ secrets.PROD_DEPLOY_SSH_USER }}@${{ secrets.PROD_DEPLOY_SSH_HOST }} 'cd ${{ secrets.PROD_DEPLOY_TARGET_DIR }} && docker compose pull
+          ssh ${{ secrets.PROD_DEPLOY_SSH_USER }}@${{ secrets.PROD_DEPLOY_SSH_HOST }} 'cd ${{ secrets.PROD_DEPLOY_TARGET_DIR }} && docker compose pull'
           ssh ${{ secrets.PROD_DEPLOY_SSH_USER }}@${{ secrets.PROD_DEPLOY_SSH_HOST }} 'cd ${{ secrets.PROD_DEPLOY_TARGET_DIR }} && docker compose up -d'


### PR DESCRIPTION
The missing closing quote in the `docker compose pull` command caused the workflow to fail. This fix ensures the command is properly formatted and the workflow executes as intended.